### PR TITLE
[Fix] GameSession DTO 네이밍 Quiz로 통일

### DIFF
--- a/back/src/main/java/com/eof/back/domain/gamesession/dto/GameSessionCreateRequest.java
+++ b/back/src/main/java/com/eof/back/domain/gamesession/dto/GameSessionCreateRequest.java
@@ -28,6 +28,6 @@ public record GameSessionCreateRequest(
 
         @NotNull(message = "최대 문제 수는 필수입니다.")
         @Min(value = 1, message = "최소 1문제 이상이어야 합니다.")
-        Integer maxQuestions
+        Integer MaxQuizzes
 ) {
 }

--- a/back/src/main/java/com/eof/back/domain/gamesession/dto/GameSessionCreateResponse.java
+++ b/back/src/main/java/com/eof/back/domain/gamesession/dto/GameSessionCreateResponse.java
@@ -38,7 +38,7 @@ public record GameSessionCreateResponse(
         Integer maxPlayers,
         String status,
         LocalDateTime createdAt,
-        Integer maxQuestions
+        Integer maxQuizzes
 ) {
 
     /**
@@ -53,7 +53,7 @@ public record GameSessionCreateResponse(
                 .maxPlayers(gameSession.getMaxPlayers())
                 .status(gameSession.getStatus().name())
                 .createdAt(gameSession.getCreatedAt())
-                .maxQuestions(gameSession.getMaxQuestions())
+                .maxQuizzes(gameSession.getMaxQuizzes())
                 .build();
     }
 }


### PR DESCRIPTION
## 💡 PR 목적
<!-- 이 PR의 목적을 설명해주세요. (예: 어떤 기능을 추가/수정/삭제했나요?) -->
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타:

## 📝 변경 사항
<!-- 변경된 내용을 구체적으로 적어주세요. -->
DTO에서 maxQuestion 관련 필드 이름을 maxQuizees로 변경하여 엔티티와 동일한 이름으로 맞춤.

## 📌 관련 이슈
<!-- PR과 관련된 이슈 번호를 적어주세요. (예: #1, #2) -->
- Close #19
