### PR TITLE
[#30][FEAT] QuizSet READ 기능 구현

### DIFF
--- a/back/src/main/java/com/eof/back/domain/quizset/controller/QuizSetController.java
+++ b/back/src/main/java/com/eof/back/domain/quizset/controller/QuizSetController.java
@@ -2,12 +2,17 @@ package com.eof.back.domain.quizset.controller;
 
 import com.eof.back.domain.quizset.dto.QuizSetCreateRequest;
 import com.eof.back.domain.quizset.dto.QuizSetCreateResponse;
+import com.eof.back.domain.quizset.dto.QuizSetListResponse;
+import com.eof.back.domain.quizset.dto.QuizSetResponse;
 import com.eof.back.domain.quizset.service.QuizSetService;
 import com.eof.back.global.response.CommonResponse;
 import com.eof.back.global.response.Response;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -42,6 +47,29 @@ public class QuizSetController {
             @RequestBody @Valid QuizSetCreateRequest request) {
 
         QuizSetCreateResponse response = quizSetService.createQuizSet(request);
+        return ResponseEntity.ok(CommonResponse.success(response));
+    }
+
+    /**
+     * 특정 퀴즈 세트의 상세 정보를 조회합니다.
+     *
+     * @param id 조회할 퀴즈 세트의 식별자
+     * @return 퀴즈 목록을 포함한 퀴즈 세트 상세 정보
+     */
+    @GetMapping("/{id}")
+    public ResponseEntity<Response<QuizSetResponse>> getQuizSet(@PathVariable Long id) {
+        QuizSetResponse response = quizSetService.getQuizSet(id);
+        return ResponseEntity.ok(CommonResponse.success(response));
+    }
+
+    /**
+     * 전체 퀴즈 세트 목록을 조회합니다.
+     *
+     * @return 퀴즈 세트 요약 정보 목록
+     */
+    @GetMapping
+    public ResponseEntity<Response<List<QuizSetListResponse>>> getAllQuizSets() {
+        List<QuizSetListResponse> response = quizSetService.getAllQuizSets();
         return ResponseEntity.ok(CommonResponse.success(response));
     }
 }

--- a/back/src/main/java/com/eof/back/domain/quizset/dto/QuizSetCreateRequest.java
+++ b/back/src/main/java/com/eof/back/domain/quizset/dto/QuizSetCreateRequest.java
@@ -35,5 +35,5 @@ public class QuizSetCreateRequest {
 
     @NotNull(message = "총 문제 수는 필수입니다.")
     @PositiveOrZero(message = "총 문제 수는 0 이상이어야 합니다.")
-    private Integer totalQuestionCount;
+    private Integer totalQuizCount;
 }

--- a/back/src/main/java/com/eof/back/domain/quizset/dto/QuizSetCreateResponse.java
+++ b/back/src/main/java/com/eof/back/domain/quizset/dto/QuizSetCreateResponse.java
@@ -30,7 +30,7 @@ public class QuizSetCreateResponse {
     private String title;
     private String description;
     private String creatorNickname;
-    private Integer totalQuestionCount;
+    private Integer totalQuizCount;
     private LocalDateTime createdAt;
 
     /**
@@ -45,7 +45,7 @@ public class QuizSetCreateResponse {
                 .title(quizSet.getTitle())
                 .description(quizSet.getDescription())
                 .creatorNickname(quizSet.getCreator().getNickname())
-                .totalQuestionCount(quizSet.getTotalQuizCount())
+                .totalQuizCount(quizSet.getTotalQuizCount())
                 .createdAt(quizSet.getCreatedAt())
                 .build();
     }

--- a/back/src/main/java/com/eof/back/domain/quizset/dto/QuizSetListResponse.java
+++ b/back/src/main/java/com/eof/back/domain/quizset/dto/QuizSetListResponse.java
@@ -1,0 +1,37 @@
+package com.eof.back.domain.quizset.dto;
+
+import com.eof.back.domain.quizset.entity.QuizSet;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 퀴즈 세트 목록 조회 시 반환되는 데이터 전송 객체입니다.
+ * <p>
+ * 목록의 각 항목으로서 퀴즈 세트의 기본 정보를 제공하며, 상세 퀴즈 목록은 포함하지 않습니다.
+ */
+@Getter
+@Builder
+public class QuizSetListResponse {
+
+    private Long id;
+    private String title;
+    private String description;
+    private String creatorNickname;
+    private Integer totalQuizCount;
+
+    /**
+     * QuizSet 엔티티로부터 QuizSetListResponse DTO를 생성합니다.
+     *
+     * @param quizSet 퀴즈 세트 엔티티
+     * @return 퀴즈 세트 목록 항목 응답 DTO
+     */
+    public static QuizSetListResponse from(QuizSet quizSet) {
+        return QuizSetListResponse.builder()
+                .id(quizSet.getId())
+                .title(quizSet.getTitle())
+                .description(quizSet.getDescription())
+                .creatorNickname(quizSet.getCreator().getNickname())
+                .totalQuizCount(quizSet.getTotalQuizCount())
+                .build();
+    }
+}

--- a/back/src/main/java/com/eof/back/domain/quizset/dto/QuizSetResponse.java
+++ b/back/src/main/java/com/eof/back/domain/quizset/dto/QuizSetResponse.java
@@ -1,0 +1,73 @@
+package com.eof.back.domain.quizset.dto;
+
+import com.eof.back.domain.quiz.entity.Quiz;
+import com.eof.back.domain.quizset.entity.QuizSet;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 퀴즈 세트 단건 조회 시 반환되는 데이터 전송 객체입니다.
+ * <p>
+ * 퀴즈 세트의 기본 정보와 더불어 해당 세트에 포함된 모든 퀴즈 목록을 포함합니다.
+ */
+@Getter
+@Builder
+public class QuizSetResponse {
+
+    private Long id;
+    private String title;
+    private String description;
+    private String creatorNickname;
+    private Integer totalQuizCount;
+    private List<QuizResponse> quizzes;
+
+    /**
+     * QuizSet 엔티티로부터 QuizSetResponse DTO를 생성합니다.
+     *
+     * @param quizSet 퀴즈 세트 엔티티
+     * @return 퀴즈 세트 응답 DTO
+     */
+    public static QuizSetResponse from(QuizSet quizSet) {
+        return QuizSetResponse.builder()
+                .id(quizSet.getId())
+                .title(quizSet.getTitle())
+                .description(quizSet.getDescription())
+                .creatorNickname(quizSet.getCreator().getNickname())
+                .totalQuizCount(quizSet.getTotalQuizCount())
+                .quizzes(quizSet.getQuizzes().stream()
+                        .map(QuizResponse::from)
+                        .collect(Collectors.toList()))
+                .build();
+    }
+
+    /**
+     * 퀴즈 세트 내 개별 퀴즈 정보를 담는 내부 DTO입니다.
+     */
+    @Getter
+    @Builder
+    public static class QuizResponse {
+        private Long id;
+        private String content;
+        private String answer;
+        private String choice1;
+        private String choice2;
+        private String choice3;
+        private String choice4;
+        private Integer sequence;
+
+        public static QuizResponse from(Quiz quiz) {
+            return QuizResponse.builder()
+                    .id(quiz.getId())
+                    .content(quiz.getContent())
+                    .answer(quiz.getAnswer())
+                    .choice1(quiz.getChoice1())
+                    .choice2(quiz.getChoice2())
+                    .choice3(quiz.getChoice3())
+                    .choice4(quiz.getChoice4())
+                    .sequence(quiz.getSequence())
+                    .build();
+        }
+    }
+}

--- a/back/src/main/java/com/eof/back/domain/quizset/entity/QuizSet.java
+++ b/back/src/main/java/com/eof/back/domain/quizset/entity/QuizSet.java
@@ -1,13 +1,18 @@
 package com.eof.back.domain.quizset.entity;
 
+import com.eof.back.domain.quiz.entity.Quiz;
 import com.eof.back.domain.user.entity.User;
 import com.eof.back.global.jpa.entity.BaseEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -22,7 +27,7 @@ import lombok.NoArgsConstructor;
  * {@link BaseEntity}를 상속받아 생성 및 수정 시간을 자동으로 관리합니다.
  *
  * <p><b>주요 생성자:</b><br>
- * {@link #QuizSet(String, String, User, Integer)} <br>
+ * {@link #QuizSet(String, String, User, Integer, List)} <br>
  * 빌더 패턴을 통해 제목, 설명, 제작자, 총 퀴즈 수를 입력받아 인스턴스를 생성합니다. <br>
  *
  * @author MintyU
@@ -61,19 +66,29 @@ public class QuizSet extends BaseEntity {
     private Integer totalQuizCount;
 
     /**
+     * 이 퀴즈 세트에 포함된 개별 퀴즈 목록입니다.
+     */
+    @OneToMany(mappedBy = "quizSet", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Quiz> quizzes = new ArrayList<>();
+
+    /**
      * 빌더 패턴을 이용한 생성자입니다.
      *
      * @param title 제목
      * @param description 설명
      * @param creator 제작자
      * @param totalQuizCount 총 퀴즈 수
+     * @param quizzes 퀴즈 목록
      */
     @Builder
-    private QuizSet(String title, String description, User creator, Integer totalQuizCount) {
+    private QuizSet(String title, String description, User creator, Integer totalQuizCount, List<Quiz> quizzes) {
         this.title = title;
         this.description = description;
         this.creator = creator;
         this.totalQuizCount = totalQuizCount;
+        if (quizzes != null) {
+            this.quizzes = quizzes;
+        }
     }
 
     /**

--- a/back/src/main/java/com/eof/back/domain/quizset/service/QuizSetService.java
+++ b/back/src/main/java/com/eof/back/domain/quizset/service/QuizSetService.java
@@ -2,6 +2,9 @@ package com.eof.back.domain.quizset.service;
 
 import com.eof.back.domain.quizset.dto.QuizSetCreateRequest;
 import com.eof.back.domain.quizset.dto.QuizSetCreateResponse;
+import com.eof.back.domain.quizset.dto.QuizSetListResponse;
+import com.eof.back.domain.quizset.dto.QuizSetResponse;
+import java.util.List;
 
 /**
  * 퀴즈 세트(QuizSet) 도메인의 비즈니스 로직을 정의하는 서비스 인터페이스입니다.
@@ -40,4 +43,25 @@ public interface QuizSetService {
      * @throws RuntimeException (임시) 제작자 정보를 찾을 수 없을 경우 발생합니다.
      */
     QuizSetCreateResponse createQuizSet(QuizSetCreateRequest request);
+
+    /**
+     * 특정 식별자(ID)를 가진 퀴즈 세트의 상세 정보를 조회합니다.
+     * <p>
+     * 이 메서드는 퀴즈 세트의 기본 정보뿐만 아니라 소속된 모든 퀴즈 목록을 함께 반환합니다.
+     *
+     * @param id 조회할 퀴즈 세트의 식별자
+     * @return 퀴즈 목록을 포함한 퀴즈 세트 상세 정보
+     * @throws com.eof.back.global.exception.exceptions.QuizSetException 해당 ID의 퀴즈 세트가 존재하지 않을 경우 발생합니다.
+     */
+    QuizSetResponse getQuizSet(Long id);
+
+    /**
+     * 시스템에 등록된 모든 퀴즈 세트 목록을 조회합니다.
+     * <p>
+     * 목록 조회 시에는 데이터 전송 효율을 위해 개별 퀴즈들의 상세 목록은 제외하고,
+     * 각 퀴즈 세트의 요약 정보(제목, 제작자, 총 문제 수 등)만 반환합니다.
+     *
+     * @return 등록된 모든 퀴즈 세트의 요약 정보 목록
+     */
+    List<QuizSetListResponse> getAllQuizSets();
 }

--- a/back/src/main/java/com/eof/back/domain/quizset/service/QuizSetServiceImpl.java
+++ b/back/src/main/java/com/eof/back/domain/quizset/service/QuizSetServiceImpl.java
@@ -2,10 +2,16 @@ package com.eof.back.domain.quizset.service;
 
 import com.eof.back.domain.quizset.dto.QuizSetCreateRequest;
 import com.eof.back.domain.quizset.dto.QuizSetCreateResponse;
+import com.eof.back.domain.quizset.dto.QuizSetListResponse;
+import com.eof.back.domain.quizset.dto.QuizSetResponse;
 import com.eof.back.domain.quizset.entity.QuizSet;
 import com.eof.back.domain.quizset.repository.QuizSetRepository;
 import com.eof.back.domain.user.entity.User;
 import com.eof.back.domain.user.repository.UserRepository;
+import com.eof.back.global.exception.errorCode.QuizSetErrorCode;
+import com.eof.back.global.exception.exceptions.QuizSetException;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -37,8 +43,6 @@ public class QuizSetServiceImpl implements QuizSetService {
     @Transactional
     public QuizSetCreateResponse createQuizSet(QuizSetCreateRequest request) {
         // TODO: 인증 기능 구현 후 현재 로그인된 사용자 정보를 가져오도록 수정
-        // 현재는 임시로 ID가 1L인 사용자를 제작자로 설정하거나, 없을 경우 에러 처리가 필요하나
-        // 여기서는 임시 Mock 로직으로 처리합니다.
         User creator = userRepository.findById(1L)
                 .orElseThrow(() -> new RuntimeException("임시 사용자(ID: 1)를 찾을 수 없습니다."));
 
@@ -46,11 +50,36 @@ public class QuizSetServiceImpl implements QuizSetService {
                 .title(request.getTitle())
                 .description(request.getDescription())
                 .creator(creator)
-                .totalQuizCount(request.getTotalQuestionCount())
+                .totalQuizCount(request.getTotalQuizCount())
                 .build();
 
         QuizSet savedQuizSet = quizSetRepository.save(quizSet);
 
         return QuizSetCreateResponse.from(savedQuizSet);
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * 지정된 ID로 {@link QuizSetRepository}에서 조회하며,
+     * 해당 엔티티가 존재하지 않을 경우 {@link QuizSetException}을 발생시킵니다.
+     */
+    @Override
+    public QuizSetResponse getQuizSet(Long id) {
+        QuizSet quizSet = quizSetRepository.findById(id)
+                .orElseThrow(() -> new QuizSetException(QuizSetErrorCode.QUIZ_SET_NOT_FOUND));
+        return QuizSetResponse.from(quizSet);
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * 전체 {@link QuizSet} 엔티티를 조회한 후, 요약 정보만 포함된 {@link QuizSetListResponse} 목록으로 변환합니다.
+     */
+    @Override
+    public List<QuizSetListResponse> getAllQuizSets() {
+        return quizSetRepository.findAll().stream()
+                .map(QuizSetListResponse::from)
+                .collect(Collectors.toList());
     }
 }

--- a/back/src/test/java/com/eof/back/domain/quizset/controller/QuizSetControllerTest.java
+++ b/back/src/test/java/com/eof/back/domain/quizset/controller/QuizSetControllerTest.java
@@ -1,7 +1,9 @@
 package com.eof.back.domain.quizset.controller;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -9,10 +11,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.eof.back.domain.quizset.dto.QuizSetCreateRequest;
 import com.eof.back.domain.quizset.dto.QuizSetCreateResponse;
+import com.eof.back.domain.quizset.dto.QuizSetListResponse;
+import com.eof.back.domain.quizset.dto.QuizSetResponse;
 import com.eof.back.domain.quizset.service.QuizSetService;
+import com.eof.back.global.exception.errorCode.QuizSetErrorCode;
+import com.eof.back.global.exception.exceptions.QuizSetException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -39,7 +46,7 @@ class QuizSetControllerTest {
         QuizSetCreateRequest request = QuizSetCreateRequest.builder()
                 .title("API 테스트 퀴즈 세트")
                 .description("API 설명")
-                .totalQuestionCount(5)
+                .totalQuizCount(5)
                 .build();
 
         QuizSetCreateResponse response = QuizSetCreateResponse.builder()
@@ -47,7 +54,7 @@ class QuizSetControllerTest {
                 .title(request.getTitle())
                 .description(request.getDescription())
                 .creatorNickname("작성자")
-                .totalQuestionCount(5)
+                .totalQuizCount(5)
                 .createdAt(LocalDateTime.now())
                 .build();
 
@@ -61,7 +68,7 @@ class QuizSetControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("success"))
                 .andExpect(jsonPath("$.data.title").value("API 테스트 퀴즈 세트"))
-                .andExpect(jsonPath("$.data.totalQuestionCount").value(5))
+                .andExpect(jsonPath("$.data.totalQuizCount").value(5))
                 .andExpect(jsonPath("$.data.creatorNickname").value("작성자"));
     }
 
@@ -72,7 +79,7 @@ class QuizSetControllerTest {
         QuizSetCreateRequest request = QuizSetCreateRequest.builder()
                 .title("")
                 .description("API 설명")
-                .totalQuestionCount(5)
+                .totalQuizCount(5)
                 .build();
 
         // when & then
@@ -91,7 +98,7 @@ class QuizSetControllerTest {
         QuizSetCreateRequest request = QuizSetCreateRequest.builder()
                 .title("제목")
                 .description("API 설명")
-                .totalQuestionCount(-1)
+                .totalQuizCount(-1)
                 .build();
 
         // when & then
@@ -111,7 +118,7 @@ class QuizSetControllerTest {
         QuizSetCreateRequest request = QuizSetCreateRequest.builder()
                 .title("제목")
                 .description(longDescription)
-                .totalQuestionCount(5)
+                .totalQuizCount(5)
                 .build();
 
         // when & then
@@ -122,5 +129,84 @@ class QuizSetControllerTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.status").value("fail"))
                 .andExpect(jsonPath("$.message").value("description: 퀴즈 세트 설명은 1000자를 초과할 수 없습니다."));
+    }
+
+    @Test
+    @DisplayName("퀴즈 세트 단건 조회 API 호출 성공")
+    void getQuizSet_ApiSuccess() throws Exception {
+        // given
+        QuizSetResponse.QuizResponse quizResponse = QuizSetResponse.QuizResponse.builder()
+                .id(1L)
+                .content("문제 내용")
+                .answer("정답")
+                .choice1("1")
+                .choice2("2")
+                .choice3("3")
+                .choice4("4")
+                .sequence(1)
+                .build();
+
+        QuizSetResponse response = QuizSetResponse.builder()
+                .id(1L)
+                .title("테스트 세트")
+                .description("설명")
+                .creatorNickname("작성자")
+                .totalQuizCount(1)
+                .quizzes(List.of(quizResponse))
+                .build();
+
+        given(quizSetService.getQuizSet(anyLong())).willReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/quizsets/1"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("success"))
+                .andExpect(jsonPath("$.data.id").value(1))
+                .andExpect(jsonPath("$.data.title").value("테스트 세트"))
+                .andExpect(jsonPath("$.data.quizzes[0].content").value("문제 내용"));
+    }
+
+    @Test
+    @DisplayName("퀴즈 세트 단건 조회 실패 - 존재하지 않는 식별자")
+    void getQuizSet_ApiFail_NotFound() throws Exception {
+        // given
+        given(quizSetService.getQuizSet(anyLong()))
+                .willThrow(new QuizSetException(QuizSetErrorCode.QUIZ_SET_NOT_FOUND));
+
+        // when & then
+        mockMvc.perform(get("/api/v1/quizsets/999"))
+                .andDo(print())
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value("fail"))
+                .andExpect(jsonPath("$.message").value("해당 퀴즈 세트를 찾을 수 없습니다."));
+    }
+
+    @Test
+    @DisplayName("퀴즈 세트 전체 목록 조회 API 호출 성공")
+    void getAllQuizSets_ApiSuccess() throws Exception {
+        // given
+        QuizSetListResponse response1 = QuizSetListResponse.builder()
+                .id(1L)
+                .title("세트1")
+                .creatorNickname("작성자1")
+                .totalQuizCount(5)
+                .build();
+        QuizSetListResponse response2 = QuizSetListResponse.builder()
+                .id(2L)
+                .title("세트2")
+                .creatorNickname("작성자2")
+                .totalQuizCount(10)
+                .build();
+
+        given(quizSetService.getAllQuizSets()).willReturn(List.of(response1, response2));
+
+        // when & then
+        mockMvc.perform(get("/api/v1/quizsets"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("success"))
+                .andExpect(jsonPath("$.data[0].title").value("세트1"))
+                .andExpect(jsonPath("$.data[1].title").value("세트2"));
     }
 }

--- a/back/src/test/java/com/eof/back/domain/quizset/service/QuizSetServiceTest.java
+++ b/back/src/test/java/com/eof/back/domain/quizset/service/QuizSetServiceTest.java
@@ -6,13 +6,18 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
+import com.eof.back.domain.quiz.entity.Quiz;
 import com.eof.back.domain.quizset.dto.QuizSetCreateRequest;
 import com.eof.back.domain.quizset.dto.QuizSetCreateResponse;
+import com.eof.back.domain.quizset.dto.QuizSetListResponse;
+import com.eof.back.domain.quizset.dto.QuizSetResponse;
 import com.eof.back.domain.quizset.entity.QuizSet;
 import com.eof.back.domain.quizset.repository.QuizSetRepository;
 import com.eof.back.domain.user.entity.Role;
 import com.eof.back.domain.user.entity.User;
 import com.eof.back.domain.user.repository.UserRepository;
+import com.eof.back.global.exception.exceptions.QuizSetException;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -41,7 +46,7 @@ class QuizSetServiceTest {
         QuizSetCreateRequest request = QuizSetCreateRequest.builder()
                 .title("테스트 퀴즈 세트")
                 .description("설명")
-                .totalQuestionCount(10)
+                .totalQuizCount(10)
                 .build();
 
         User creator = User.builder()
@@ -56,7 +61,7 @@ class QuizSetServiceTest {
                 .title(request.getTitle())
                 .description(request.getDescription())
                 .creator(creator)
-                .totalQuizCount(request.getTotalQuestionCount())
+                .totalQuizCount(request.getTotalQuizCount())
                 .build();
         ReflectionTestUtils.setField(quizSet, "id", 100L);
 
@@ -70,7 +75,7 @@ class QuizSetServiceTest {
         assertThat(response.getId()).isEqualTo(100L);
         assertThat(response.getTitle()).isEqualTo("테스트 퀴즈 세트");
         assertThat(response.getCreatorNickname()).isEqualTo("별명");
-        assertThat(response.getTotalQuestionCount()).isEqualTo(10);
+        assertThat(response.getTotalQuizCount()).isEqualTo(10);
         
         verify(userRepository).findById(1L);
         verify(quizSetRepository).save(any(QuizSet.class));
@@ -83,7 +88,7 @@ class QuizSetServiceTest {
         QuizSetCreateRequest request = QuizSetCreateRequest.builder()
                 .title("테스트 퀴즈 세트")
                 .description("설명")
-                .totalQuestionCount(10)
+                .totalQuizCount(10)
                 .build();
 
         given(userRepository.findById(1L)).willReturn(Optional.empty());
@@ -94,5 +99,73 @@ class QuizSetServiceTest {
                 .hasMessageContaining("임시 사용자(ID: 1)를 찾을 수 없습니다.");
         
         verify(userRepository).findById(1L);
+    }
+
+    @Test
+    @DisplayName("퀴즈 세트 단건 조회 성공")
+    void getQuizSet_Success() {
+        // given
+        User creator = User.builder().nickname("별명").build();
+        QuizSet quizSet = QuizSet.builder()
+                .title("테스트 세트")
+                .description("설명")
+                .creator(creator)
+                .totalQuizCount(1)
+                .build();
+        ReflectionTestUtils.setField(quizSet, "id", 1L);
+
+        Quiz quiz = Quiz.builder()
+                .content("문제 내용")
+                .answer("정답")
+                .choice1("1")
+                .choice2("2")
+                .choice3("3")
+                .choice4("4")
+                .sequence(1)
+                .build();
+        ReflectionTestUtils.setField(quiz, "id", 10L);
+        quizSet.getQuizzes().add(quiz);
+
+        given(quizSetRepository.findById(1L)).willReturn(Optional.of(quizSet));
+
+        // when
+        QuizSetResponse response = quizSetService.getQuizSet(1L);
+
+        // then
+        assertThat(response.getId()).isEqualTo(1L);
+        assertThat(response.getQuizzes()).hasSize(1);
+        assertThat(response.getQuizzes().get(0).getContent()).isEqualTo("문제 내용");
+        verify(quizSetRepository).findById(1L);
+    }
+
+    @Test
+    @DisplayName("퀴즈 세트 단건 조회 실패 - 존재하지 않음")
+    void getQuizSet_Fail_NotFound() {
+        // given
+        given(quizSetRepository.findById(1L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> quizSetService.getQuizSet(1L))
+                .isInstanceOf(QuizSetException.class);
+    }
+
+    @Test
+    @DisplayName("퀴즈 세트 전체 목록 조회 성공")
+    void getAllQuizSets_Success() {
+        // given
+        User creator = User.builder().nickname("별명").build();
+        QuizSet quizSet1 = QuizSet.builder().title("세트1").creator(creator).totalQuizCount(5).build();
+        QuizSet quizSet2 = QuizSet.builder().title("세트2").creator(creator).totalQuizCount(10).build();
+
+        given(quizSetRepository.findAll()).willReturn(List.of(quizSet1, quizSet2));
+
+        // when
+        List<QuizSetListResponse> responses = quizSetService.getAllQuizSets();
+
+        // then
+        assertThat(responses).hasSize(2);
+        assertThat(responses.get(0).getTitle()).isEqualTo("세트1");
+        assertThat(responses.get(1).getTitle()).isEqualTo("세트2");
+        verify(quizSetRepository).findAll();
     }
 }


### PR DESCRIPTION
## 💡 PR 목적
<!-- 이 PR의 목적을 설명해주세요. (예: 어떤 기능을 추가/수정/삭제했나요?) -->
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타:

## 📝 변경 사항
<!-- 변경된 내용을 구체적으로 적어주세요. -->
- QuizSet의 Read 기능이 추가되었습니다.
- Service와 ServiceImpl을 분리했습니다.
- QuizSet의 단건 조회 시 출력되는 Quiz 목록에 대한 DTO는 임시로 구현했습니다.
- TODO : Quiz의 DTO가 작업이 되면 이후 통합 예정입니다.

## 📌 관련 이슈
<!-- PR과 관련된 이슈 번호를 적어주세요. (예: #1, #2) -->
- Close #30 
