### PR TITLE
[#149][Feat] User 다건조회 구현

### DIFF
--- a/back/src/main/java/com/eof/back/admin/controller/AdminController.java
+++ b/back/src/main/java/com/eof/back/admin/controller/AdminController.java
@@ -1,5 +1,6 @@
 package com.eof.back.admin.controller;
 
+import com.eof.back.admin.dto.AdminUserResponse;
 import com.eof.back.admin.service.AdminService;
 import com.eof.back.domain.quiz.dto.QuizUpdateRequest;
 import com.eof.back.domain.quizreport.dto.QuizReportResponse;
@@ -13,6 +14,8 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -21,6 +24,7 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
@@ -202,6 +206,23 @@ public class AdminController {
             @AuthenticationPrincipal UserPrincipal principal) {
         adminService.deleteUser(userId, principal.id());
         return ResponseEntity.ok(CommonResponse.success(null, "사용자가 삭제(탈퇴) 처리되었습니다."));
+    }
+
+    /**
+     * 전체 사용자 목록을 페이징하여 조회합니다. (닉네임 검색 필터 지원)
+     *
+     * @param keyword   검색어 (닉네임, 선택 사항)
+     * @param pageable  페이징 정보 (size, page, sort)
+     * @param principal 인증된 관리자 정보
+     * @return 페이징 처리된 사용자 목록
+     */
+    @GetMapping("/users")
+    public ResponseEntity<Response<Slice<AdminUserResponse>>> getUsers(
+            @RequestParam(required = false) String keyword,
+            Pageable pageable,
+            @AuthenticationPrincipal UserPrincipal principal) {
+        Slice<AdminUserResponse> users = adminService.getUsers(keyword, pageable, principal.id());
+        return ResponseEntity.ok(CommonResponse.success(users));
     }
 
     /**

--- a/back/src/main/java/com/eof/back/admin/dto/AdminUserResponse.java
+++ b/back/src/main/java/com/eof/back/admin/dto/AdminUserResponse.java
@@ -1,0 +1,42 @@
+package com.eof.back.admin.dto;
+
+import com.eof.back.domain.user.user.entity.Role;
+import com.eof.back.domain.user.user.entity.User;
+import com.eof.back.domain.user.user.entity.UserStatus;
+import java.time.LocalDateTime;
+
+/**
+ * 관리자 페이지에서 사용자 정보를 조회할 때 사용하는 응답 DTO입니다.
+ *
+ * @param id                사용자 식별자
+ * @param username          사용자 아이디
+ * @param nickname          사용자 닉네임
+ * @param email             사용자 이메일
+ * @param role              사용자 권한
+ * @param status            사용자 상태
+ * @param totalRankingScore 누적 랭킹 점수
+ * @param createdAt         가입 일시
+ */
+public record AdminUserResponse(
+        Long id,
+        String username,
+        String nickname,
+        String email,
+        Role role,
+        UserStatus status,
+        Long totalRankingScore,
+        LocalDateTime createdAt
+) {
+    public static AdminUserResponse from(User user) {
+        return new AdminUserResponse(
+                user.getId(),
+                user.getUsername(),
+                user.getNickname(),
+                user.getEmail(),
+                user.getRole(),
+                user.getStatus(),
+                user.getTotalRankingScore(),
+                user.getCreatedAt()
+        );
+    }
+}

--- a/back/src/main/java/com/eof/back/admin/service/AdminService.java
+++ b/back/src/main/java/com/eof/back/admin/service/AdminService.java
@@ -1,9 +1,12 @@
 package com.eof.back.admin.service;
 
+import com.eof.back.admin.dto.AdminUserResponse;
 import com.eof.back.domain.quiz.dto.QuizUpdateRequest;
 import com.eof.back.domain.quizreport.dto.QuizReportResponse;
 import com.eof.back.domain.quizset.dto.QuizSetUpdateRequest;
 import java.util.List;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Pageable;
 
 /**
  * 서비스의 모든 관리자 전용 기능을 정의하는 비즈니스 로직 계층 인터페이스입니다.
@@ -117,4 +120,15 @@ public interface AdminService {
      * @param adminId      요청을 보낸 관리자의 식별자 (권한 검증용)
      */
     void deleteUser(Long targetUserId, Long adminId);
+
+    /**
+     * 전체 사용자 목록을 페이징하여 조회합니다.
+     * 검색어(keyword)가 제공되면 닉네임에 포함된 사용자를 검색합니다.
+     *
+     * @param keyword  검색어 (닉네임)
+     * @param pageable 페이징 정보
+     * @param adminId  요청을 보낸 관리자의 식별자 (권한 검증용)
+     * @return 페이징 처리된 사용자 목록 응답
+     */
+    Slice<AdminUserResponse> getUsers(String keyword, Pageable pageable, Long adminId);
 }

--- a/back/src/main/java/com/eof/back/admin/service/AdminServiceImpl.java
+++ b/back/src/main/java/com/eof/back/admin/service/AdminServiceImpl.java
@@ -1,5 +1,6 @@
 package com.eof.back.admin.service;
 
+import com.eof.back.admin.dto.AdminUserResponse;
 import com.eof.back.admin.entity.UserSuspension;
 import com.eof.back.admin.repository.UserSuspensionRepository;
 import com.eof.back.domain.quiz.dto.QuizUpdateRequest;
@@ -30,6 +31,8 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -203,6 +206,23 @@ public class AdminServiceImpl implements AdminService {
         
         user.delete();
         userSuspensionRepository.deleteByUserId(targetUserId);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Slice<AdminUserResponse> getUsers(String keyword, Pageable pageable, Long adminId) {
+        validateAdminRole(adminId);
+
+        Slice<User> users;
+        if (keyword != null && !keyword.isBlank()) {
+            users = userRepository.findByNicknameContaining(keyword, pageable);
+        } else {
+            users = userRepository.findAllBy(pageable);
+        }
+
+        return users.map(AdminUserResponse::from);
     }
 
     /**

--- a/back/src/main/java/com/eof/back/domain/user/user/repository/UserRepository.java
+++ b/back/src/main/java/com/eof/back/domain/user/user/repository/UserRepository.java
@@ -3,6 +3,7 @@ package com.eof.back.domain.user.user.repository;
 import com.eof.back.domain.user.user.entity.AuthProvider;
 import com.eof.back.domain.user.user.entity.User;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -52,4 +53,8 @@ public interface UserRepository extends JpaRepository<User,Long> {
             "OR (u.totalRankingScore = (SELECT u2.totalRankingScore FROM User u2 WHERE u2.id = :userId) " +
             "AND u.id < :userId))")
     Long findMyRankByUserId(@Param("userId") Long userId);
+
+    Slice<User> findByNicknameContaining(String nickname, Pageable pageable);
+
+    Slice<User> findAllBy(Pageable pageable);
 }


### PR DESCRIPTION
## 💡 PR 목적
<!-- 이 PR의 목적을 설명해주세요. (예: 어떤 기능을 추가/수정/삭제했나요?) -->
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타:

## 📝 변경 사항
<!-- 변경된 내용을 구체적으로 적어주세요. -->
관리자 페이지에서 사용하는 유저 다건 조회 기능이 추가되었습니다.

검색은 닉네임을 기준으로 진행됩니다.

`@RequestParam(required = false) String keyword`에 키워드(닉네임)을 입력하여 검색할 수 있고, Slice를 통한 페이징이 적용된 검색 결과를 출력합니다. 키워드가 제공되지 않으면 전체 목록을 조회합니다.

## 📌 관련 이슈
<!-- PR과 관련된 이슈 번호를 적어주세요. (예: #1, #2) -->
- Close #149 
