### PR TITLE
[FEAT] 마이페이지 내 정보 수정 연동(닉네임/비밀번호 변경)

### DIFF
--- a/front/src/app/(main)/users/[userId]/page.tsx
+++ b/front/src/app/(main)/users/[userId]/page.tsx
@@ -66,11 +66,8 @@ export default function MyPage() {
       await api.patch(`/users/${myUserId}`, body);
       if (newNickname.trim()) {
         localStorage.setItem("nickname", newNickname);
-        setUser((prev) => prev ? { ...prev, nickname: newNickname } : prev);
       }
-      setIsEditing(false);
-      setNewNickname("");
-      setNewPassword("");
+      window.location.reload();
     } catch (err: any) {
       setUpdateError(err.response?.data?.message || "수정에 실패했습니다.");
     } finally {
@@ -84,7 +81,7 @@ export default function MyPage() {
     try {
       await api.delete("/auth/withdraw");
       localStorage.clear();
-      router.push("/");
+      window.location.href = "/";  // router.push 대신 이걸로
     } catch (err) {
       alert("탈퇴에 실패했습니다.");
     } finally {


### PR DESCRIPTION
## 💡 PR 목적
<!-- 이 PR의 목적을 설명해주세요. (예: 어떤 기능을 추가/수정/삭제했나요?) -->
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타:

## 📝 변경 사항
<!-- 변경된 내용을 구체적으로 적어주세요. -->
- 마이페이지 내 정보 수정 기능 추가 (닉네임, 비밀번호 선택적 변경)
- 마이페이지 회원 탈퇴 기능 추가 (탈퇴 후 로컬스토리지 초기화 및 메인 페이지 리다이렉트)
- 수정하기 버튼 클릭 시 인라인 폼 표시, 취소 시 폼 숨김 처리
- 닉네임 변경 성공 시 localStorage 닉네임 즉시 반영

## 🛠️ 테스트 방법
<!-- 이 PR이 의도한 대로 동작하는지 테스트한 방법과 결과를 작성해주세요. -->
<img width="830" height="656" alt="image" src="https://github.com/user-attachments/assets/c36750cb-08aa-4309-abaf-c0154d341b19" />
<img width="822" height="821" alt="image" src="https://github.com/user-attachments/assets/6bff29d9-5381-4070-b622-061f2b2c3ddf" />

## 📌 관련 이슈
<!-- PR과 관련된 이슈 번호를 적어주세요. (예: #1, #2) -->
- Close #159
