### PR TITLE
[#207][Hotfix] 썸네일 삭제 안됨 문제 해결

### DIFF
--- a/back/src/main/java/com/eof/back/admin/service/AdminServiceImpl.java
+++ b/back/src/main/java/com/eof/back/admin/service/AdminServiceImpl.java
@@ -5,6 +5,7 @@ import com.eof.back.admin.entity.UserSuspension;
 import com.eof.back.admin.repository.UserSuspensionRepository;
 import com.eof.back.domain.auth.store.RefreshTokenStore;
 import com.eof.back.global.token.TokenVersionStore;
+import com.eof.back.domain.image.service.ImageService;
 import com.eof.back.domain.quiz.dto.QuizUpdateRequest;
 import com.eof.back.domain.quiz.entity.Quiz;
 import com.eof.back.domain.quiz.repository.QuizRepository;
@@ -63,6 +64,7 @@ public class AdminServiceImpl implements AdminService {
     private final GameSessionRepository gameSessionRepository;
     private final RefreshTokenStore refreshTokenStore;
     private final TokenVersionStore tokenVersionStore;
+    private final ImageService imageService;
 
     /**
      * {@inheritDoc}
@@ -72,7 +74,13 @@ public class AdminServiceImpl implements AdminService {
     public Long updateQuizSet(Long id, QuizSetUpdateRequest request, Long adminId) {
         validateAdminRole(adminId);
         QuizSet quizSet = findQuizSetById(id);
-        quizSet.update(request.title(), request.description(), request.thumbnailUrl());
+
+        String newThumbnailUrl = request.thumbnailUrl();
+        if (newThumbnailUrl != null && newThumbnailUrl.isBlank()) {
+            imageService.deleteImage(quizSet.getThumbnailUrl(), adminId);
+        }
+
+        quizSet.update(request.title(), request.description(), newThumbnailUrl);
         return quizSet.getId();
     }
 

--- a/back/src/main/java/com/eof/back/domain/quizset/entity/QuizSet.java
+++ b/back/src/main/java/com/eof/back/domain/quizset/entity/QuizSet.java
@@ -118,9 +118,11 @@ public class QuizSet extends BaseEntity {
     /**
      * 퀴즈 세트의 정보를 수정합니다. (PATCH 목적)
      * null이 아닌 필드만 업데이트합니다.
+     * thumbnailUrl이 빈 문자열("")이면 썸네일을 삭제(null)합니다.
      *
      * @param title 새로운 제목
      * @param description 새로운 설명
+     * @param thumbnailUrl 새로운 썸네일 URL (null=변경없음, ""=삭제)
      */
     public void update(String title, String description, String thumbnailUrl) {
         if (title != null && !title.isBlank()) {
@@ -130,7 +132,7 @@ public class QuizSet extends BaseEntity {
             this.description = description;
         }
         if (thumbnailUrl != null) {
-            this.thumbnailUrl = thumbnailUrl;
+            this.thumbnailUrl = thumbnailUrl.isBlank() ? null : thumbnailUrl;
         }
     }
 

--- a/back/src/main/java/com/eof/back/domain/quizset/service/QuizSetServiceImpl.java
+++ b/back/src/main/java/com/eof/back/domain/quizset/service/QuizSetServiceImpl.java
@@ -1,6 +1,7 @@
 package com.eof.back.domain.quizset.service;
 
 import com.eof.back.domain.gamesession.repository.GameSessionRepository;
+import com.eof.back.domain.image.service.ImageService;
 import com.eof.back.domain.quiz.repository.QuizRepository;
 import com.eof.back.domain.quizset.dto.QuizSetCreateRequest;
 import com.eof.back.domain.quizset.dto.QuizSetInfoResponse;
@@ -44,6 +45,7 @@ public class QuizSetServiceImpl implements QuizSetService {
     private final QuizSetBookmarkRepository quizSetBookmarkRepository;
     private final GameSessionRepository gameSessionRepository;
     private final GameRecordRepository gameRecordRepository;
+    private final ImageService imageService;
 
     /**
      * {@inheritDoc}
@@ -107,7 +109,12 @@ public class QuizSetServiceImpl implements QuizSetService {
         QuizSet quizSet = findQuizSetById(id);
         validateCreator(quizSet, userId);
 
-        quizSet.update(request.title(), request.description(), request.thumbnailUrl());
+        String newThumbnailUrl = request.thumbnailUrl();
+        if (newThumbnailUrl != null && newThumbnailUrl.isBlank()) {
+            imageService.deleteImage(quizSet.getThumbnailUrl(), userId);
+        }
+
+        quizSet.update(request.title(), request.description(), newThumbnailUrl);
         return quizSet.getId();
     }
 

--- a/back/src/test/java/com/eof/back/admin/service/AdminServiceTest.java
+++ b/back/src/test/java/com/eof/back/admin/service/AdminServiceTest.java
@@ -3,12 +3,17 @@ package com.eof.back.admin.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.eof.back.admin.entity.UserSuspension;
 import com.eof.back.admin.repository.UserSuspensionRepository;
 import com.eof.back.domain.auth.store.RefreshTokenStore;
+import com.eof.back.domain.image.service.ImageService;
 import com.eof.back.domain.quiz.entity.Quiz;
 import com.eof.back.domain.quiz.repository.QuizRepository;
 import com.eof.back.domain.quizreport.entity.QuizReport;
@@ -62,6 +67,8 @@ class AdminServiceTest {
     private RefreshTokenStore refreshTokenStore;
     @Mock
     private TokenVersionStore tokenVersionStore;
+    @Mock
+    private ImageService imageService;
 
     private User admin;
     private User user;
@@ -93,6 +100,51 @@ class AdminServiceTest {
 
         // then
         assertThat(quizSet.getTitle()).isEqualTo("수정 제목");
+    }
+
+    @Test
+    @DisplayName("관리자 권한으로 퀴즈 세트 수정 성공 - 썸네일 삭제 (빈 문자열)")
+    void updateQuizSet_ThumbnailDelete_Success() {
+        // given
+        QuizSet quizSet = QuizSet.builder()
+                .title("기본 제목")
+                .thumbnailUrl("https://s3.example.com/old-thumb.jpg")
+                .build();
+        ReflectionTestUtils.setField(quizSet, "id", 100L);
+        QuizSetUpdateRequest request = new QuizSetUpdateRequest("기본 제목", null, "");
+
+        given(userRepository.findById(adminId)).willReturn(Optional.of(admin));
+        given(quizSetRepository.findById(100L)).willReturn(Optional.of(quizSet));
+        willDoNothing().given(imageService).deleteImage(anyString(), eq(adminId));
+
+        // when
+        adminService.updateQuizSet(100L, request, adminId);
+
+        // then
+        verify(imageService).deleteImage("https://s3.example.com/old-thumb.jpg", adminId);
+        assertThat(quizSet.getThumbnailUrl()).isNull();
+    }
+
+    @Test
+    @DisplayName("관리자 권한으로 퀴즈 세트 수정 성공 - thumbnailUrl null이면 기존 썸네일 유지")
+    void updateQuizSet_ThumbnailNotChanged_WhenNull() {
+        // given
+        QuizSet quizSet = QuizSet.builder()
+                .title("기본 제목")
+                .thumbnailUrl("https://s3.example.com/old-thumb.jpg")
+                .build();
+        ReflectionTestUtils.setField(quizSet, "id", 100L);
+        QuizSetUpdateRequest request = new QuizSetUpdateRequest("수정 제목", "설명", null);
+
+        given(userRepository.findById(adminId)).willReturn(Optional.of(admin));
+        given(quizSetRepository.findById(100L)).willReturn(Optional.of(quizSet));
+
+        // when
+        adminService.updateQuizSet(100L, request, adminId);
+
+        // then
+        verify(imageService, never()).deleteImage(anyString(), any());
+        assertThat(quizSet.getThumbnailUrl()).isEqualTo("https://s3.example.com/old-thumb.jpg");
     }
 
     @Test

--- a/back/src/test/java/com/eof/back/domain/quizset/service/QuizSetServiceTest.java
+++ b/back/src/test/java/com/eof/back/domain/quizset/service/QuizSetServiceTest.java
@@ -3,10 +3,15 @@ package com.eof.back.domain.quizset.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.eof.back.domain.gamesession.repository.GameSessionRepository;
+import com.eof.back.domain.image.service.ImageService;
 import com.eof.back.domain.quiz.entity.Quiz;
 import com.eof.back.domain.quiz.repository.QuizRepository;
 import com.eof.back.domain.quizset.dto.QuizSetCreateRequest;
@@ -62,6 +67,9 @@ class QuizSetServiceTest {
 
     @Mock
     private GameRecordRepository gameRecordRepository;
+
+    @Mock
+    private ImageService imageService;
 
     @Test
     @DisplayName("퀴즈 세트 생성 성공")
@@ -237,6 +245,57 @@ class QuizSetServiceTest {
         // then
         assertThat(updatedId).isEqualTo(100L);
         assertThat(quizSet.getTitle()).isEqualTo("수정 제목");
+    }
+
+    @Test
+    @DisplayName("퀴즈 세트 수정 성공 - 썸네일 삭제 (thumbnailUrl 빈 문자열)")
+    void updateQuizSet_ThumbnailDelete_Success() {
+        // given
+        User creator = User.builder().nickname("별명").role(Role.USER).build();
+        ReflectionTestUtils.setField(creator, "id", 1L);
+        QuizSet quizSet = QuizSet.builder()
+                .title("기존 제목")
+                .thumbnailUrl("https://s3.example.com/old-thumb.jpg")
+                .creator(creator)
+                .build();
+        ReflectionTestUtils.setField(quizSet, "id", 100L);
+
+        QuizSetUpdateRequest request = new QuizSetUpdateRequest("기존 제목", null, "");
+
+        given(quizSetRepository.findById(100L)).willReturn(Optional.of(quizSet));
+        willDoNothing().given(imageService).deleteImage(anyString(), eq(1L));
+
+        // when
+        quizSetService.updateQuizSet(100L, request, 1L);
+
+        // then
+        verify(imageService).deleteImage("https://s3.example.com/old-thumb.jpg", 1L);
+        assertThat(quizSet.getThumbnailUrl()).isNull();
+    }
+
+    @Test
+    @DisplayName("퀴즈 세트 수정 성공 - thumbnailUrl null이면 기존 썸네일 유지")
+    void updateQuizSet_ThumbnailNotChanged_WhenNull() {
+        // given
+        User creator = User.builder().nickname("별명").role(Role.USER).build();
+        ReflectionTestUtils.setField(creator, "id", 1L);
+        QuizSet quizSet = QuizSet.builder()
+                .title("기존 제목")
+                .thumbnailUrl("https://s3.example.com/old-thumb.jpg")
+                .creator(creator)
+                .build();
+        ReflectionTestUtils.setField(quizSet, "id", 100L);
+
+        QuizSetUpdateRequest request = new QuizSetUpdateRequest("수정 제목", null, null);
+
+        given(quizSetRepository.findById(100L)).willReturn(Optional.of(quizSet));
+
+        // when
+        quizSetService.updateQuizSet(100L, request, 1L);
+
+        // then
+        verify(imageService, never()).deleteImage(anyString(), any());
+        assertThat(quizSet.getThumbnailUrl()).isEqualTo("https://s3.example.com/old-thumb.jpg");
     }
 
     @Test

--- a/front/src/app/(main)/quizsets/[quizsetId]/page.tsx
+++ b/front/src/app/(main)/quizsets/[quizsetId]/page.tsx
@@ -426,7 +426,7 @@ export default function QuizSetDetailPage({ params }: { params: Promise<{ quizse
       await api.patch(`/quizsets/${quizsetId}`, {
         title: editTitle,
         description: editDescription,
-        thumbnailUrl: editThumbnailUrl || undefined,
+        thumbnailUrl: editThumbnailUrl,
       });
       setQuizSet((prev) => prev ? { ...prev, title: editTitle, description: editDescription, thumbnailUrl: editThumbnailUrl || undefined } : prev);
       setIsEditing(false);


### PR DESCRIPTION
## 💡 PR 목적
<!-- 이 PR의 목적을 설명해주세요. (예: 어떤 기능을 추가/수정/삭제했나요?) -->
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타:

## 📝 변경 사항
front/src/app/(main)/quizsets/[quizsetId]/page.tsx
- PATCH 요청 시 thumbnailUrl: editThumbnailUrl || undefined → thumbnailUrl: editThumbnailUrl 로 변경
- 빈 문자열을 그대로 전송해 삭제 의도를 백엔드에 전달

QuizSet.java
- update() 메서드: thumbnailUrl이 빈 문자열("")이면 null로 저장
- 규칙: null = 변경 없음, "" = 삭제, 나머지 = 새 URL로 업데이트

QuizSetServiceImpl.java
- ImageService 의존성 주입 추가
- updateQuizSet(): thumbnailUrl == ""일 때 기존 URL로 imageService.deleteImage() 호출 → S3 파일 + Image 테이블 레코드 삭제

AdminServiceImpl.java
- 동일하게 ImageService 주입 및 썸네일 삭제 로직 추가

QuizSetServiceTest.java
- @Mock ImageService 추가 (미추가 시 NPE 위험)
- 썸네일 삭제 성공 / thumbnailUrl null 시 기존 유지 테스트 케이스 2개 추가

AdminServiceTest.java
- 동일하게 @Mock ImageService 추가 및 테스트 케이스 2개 추가

## 🛠️ 테스트 방법
- 실제 동작 테스트
- 모든 단위 테스트 통과

## 📌 관련 이슈
<!-- PR과 관련된 이슈 번호를 적어주세요. (예: #1, #2) -->
- Close #207
