### PR TITLE
[#212][Hotfix] 닉네임 변경시 game seseeion에서 바로 적용 안되는 문제 해결

### DIFF
--- a/back/src/main/java/com/eof/back/domain/auth/service/AuthService.java
+++ b/back/src/main/java/com/eof/back/domain/auth/service/AuthService.java
@@ -76,4 +76,14 @@ public interface AuthService {
      * @throws com.eof.back.global.exception.exceptions.AuthException 사용자가 없거나 이미 탈퇴한 경우
      */
     void withdraw(Long userId);
+
+    /**
+     * 닉네임 변경 후 현재 세션을 유지한 채 토큰을 재발급합니다.
+     * tokenVersion을 증가시키지 않아 기존 세션을 유지하면서,
+     * DB에서 최신 닉네임을 읽어 새 토큰에 반영합니다.
+     *
+     * @param userId 사용자 ID
+     * @return 새로 발급된 토큰 및 사용자 기본 정보
+     */
+    LoginResult reissueAfterNicknameChange(Long userId);
 }

--- a/back/src/main/java/com/eof/back/domain/auth/service/AuthServiceImpl.java
+++ b/back/src/main/java/com/eof/back/domain/auth/service/AuthServiceImpl.java
@@ -221,6 +221,26 @@ public class AuthServiceImpl implements AuthService {
         return new LoginResult(accessToken, refreshToken, user.getId(), user.getNickname(), user.getRole().name(), user.getProfileImage());
     }
 
+    @Override
+    @Transactional
+    public LoginResult reissueAfterNicknameChange(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
+
+        long storedVersion = tokenVersionStore.findByUserId(userId)
+                .orElseThrow(() -> new AuthException(AuthErrorCode.TOKEN_INVALID));
+
+        String newAccessToken = jwtTokenProvider.createAccessToken(
+                userId, user.getUsername(), user.getRole().name(), user.getNickname(), storedVersion);
+        String newRefreshToken = jwtTokenProvider.createRefreshToken(
+                userId, user.getUsername(), user.getRole().name(), user.getNickname(), storedVersion);
+
+        LocalDateTime refreshTokenExpiredAt = LocalDateTime.now().plusSeconds(refreshTokenExpireSeconds);
+        refreshTokenStore.save(userId, newRefreshToken, refreshTokenExpiredAt);
+
+        return new LoginResult(newAccessToken, newRefreshToken, userId, user.getNickname(), user.getRole().name(), user.getProfileImage());
+    }
+
     private RefreshToken validateAndGetRefreshToken(String refreshToken) {
 
         // JWT 서명 및 만료 검증

--- a/back/src/main/java/com/eof/back/domain/user/user/controller/UserController.java
+++ b/back/src/main/java/com/eof/back/domain/user/user/controller/UserController.java
@@ -1,11 +1,15 @@
 package com.eof.back.domain.user.user.controller;
 
+import com.eof.back.domain.auth.dto.LoginResult;
+import com.eof.back.domain.auth.service.AuthService;
 import com.eof.back.domain.user.user.dto.UserInfoResponse;
 import com.eof.back.domain.user.user.dto.UserUpdateRequest;
 import com.eof.back.domain.user.user.dto.UserUpdateResponse;
 import com.eof.back.domain.user.user.service.UserService;
+import com.eof.back.global.jwt.CookieUtil;
 import com.eof.back.global.response.CommonResponse;
 import com.eof.back.global.response.Response;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -29,6 +33,8 @@ import org.springframework.web.bind.annotation.*;
 public class UserController {
 
     private final UserService userService;
+    private final AuthService authService;
+    private final CookieUtil cookieUtil;
 
     /**
      * 사용자의 정보를 조회합니다.
@@ -59,9 +65,15 @@ public class UserController {
     @PatchMapping
     public ResponseEntity<Response<UserUpdateResponse>> updateMyInfo(
             @PathVariable Long userId,
-            @RequestBody @Valid UserUpdateRequest request
+            @RequestBody @Valid UserUpdateRequest request,
+            HttpServletResponse servletResponse
     ) {
         UserUpdateResponse response = userService.updateInfo(userId, request);
+
+        if (request.nickname() != null) {
+            LoginResult loginResult = authService.reissueAfterNicknameChange(userId);
+            cookieUtil.addAllTokenCookies(servletResponse, loginResult.accessToken(), loginResult.refreshToken());
+        }
 
         return ResponseEntity.ok(
                 CommonResponse.success(response, "내 정보 수정이 완료되었습니다.")

--- a/back/src/test/java/com/eof/back/domain/auth/service/AuthServiceImplTest.java
+++ b/back/src/test/java/com/eof/back/domain/auth/service/AuthServiceImplTest.java
@@ -700,4 +700,66 @@ public class AuthServiceImplTest {
                             .isEqualTo(AuthErrorCode.USER_ALREADY_DELETED));
         }
     }
+
+    @Nested
+    @DisplayName("reissueAfterNicknameChange")
+    class ReissueAfterNicknameChange {
+
+        @Test
+        @DisplayName("성공 - DB의 최신 닉네임으로 토큰을 재발급한다")
+        void success() {
+            // given
+            User user = mock(User.class);
+            given(user.getUsername()).willReturn("testUser");
+            given(user.getNickname()).willReturn("새닉네임");
+            given(user.getRole()).willReturn(Role.USER);
+            given(user.getProfileImage()).willReturn(1);
+
+            given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+            given(tokenVersionStore.findByUserId(USER_ID)).willReturn(Optional.of(TOKEN_VERSION));
+            given(jwtTokenProvider.createAccessToken(USER_ID, "testUser", "USER", "새닉네임", TOKEN_VERSION))
+                    .willReturn(NEW_ACCESS_TOKEN);
+            given(jwtTokenProvider.createRefreshToken(USER_ID, "testUser", "USER", "새닉네임", TOKEN_VERSION))
+                    .willReturn(NEW_REFRESH_TOKEN);
+
+            // when
+            LoginResult result = authService.reissueAfterNicknameChange(USER_ID);
+
+            // then
+            assertThat(result.accessToken()).isEqualTo(NEW_ACCESS_TOKEN);
+            assertThat(result.refreshToken()).isEqualTo(NEW_REFRESH_TOKEN);
+            assertThat(result.nickname()).isEqualTo("새닉네임");
+
+            verify(tokenVersionStore, never()).increment(any()); // 세션 유지 - version 증가 없음
+            verify(refreshTokenStore).save(eq(USER_ID), eq(NEW_REFRESH_TOKEN), any(LocalDateTime.class));
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 사용자면 USER_NOT_FOUND 예외가 발생한다")
+        void fail_userNotFound() {
+            // given
+            given(userRepository.findById(USER_ID)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> authService.reissueAfterNicknameChange(USER_ID))
+                    .isInstanceOf(AuthException.class)
+                    .satisfies(e -> assertThat(((AuthException) e).getErrorCode())
+                            .isEqualTo(AuthErrorCode.USER_NOT_FOUND));
+        }
+
+        @Test
+        @DisplayName("실패 - tokenVersion이 없으면 TOKEN_INVALID 예외가 발생한다")
+        void fail_tokenVersionNotFound() {
+            // given
+            User user = mock(User.class);
+            given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+            given(tokenVersionStore.findByUserId(USER_ID)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> authService.reissueAfterNicknameChange(USER_ID))
+                    .isInstanceOf(AuthException.class)
+                    .satisfies(e -> assertThat(((AuthException) e).getErrorCode())
+                            .isEqualTo(AuthErrorCode.TOKEN_INVALID));
+        }
+    }
 }

--- a/back/src/test/java/com/eof/back/domain/user/user/controller/UserControllerTest.java
+++ b/back/src/test/java/com/eof/back/domain/user/user/controller/UserControllerTest.java
@@ -1,5 +1,7 @@
 package com.eof.back.domain.user.user.controller;
 
+import com.eof.back.domain.auth.dto.LoginResult;
+import com.eof.back.domain.auth.service.AuthService;
 import com.eof.back.domain.user.user.dto.UserInfoResponse;
 import com.eof.back.domain.user.user.dto.UserUpdateResponse;
 import com.eof.back.domain.user.user.service.UserService;
@@ -25,6 +27,8 @@ import org.springframework.test.web.servlet.MockMvc;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -40,6 +44,9 @@ class UserControllerTest {
 
     @MockitoBean
     private UserService userService;
+
+    @MockitoBean
+    private AuthService authService;
 
     @MockitoBean
     private JwtTokenProvider jwtTokenProvider;
@@ -90,20 +97,44 @@ class UserControllerTest {
     class UpdateMyInfo {
 
         @Test
-        @DisplayName("성공 - 사용자 정보를 수정하고 반환한다")
-        void success() throws Exception {
+        @DisplayName("성공 - 닉네임 변경 시 토큰 재발급 후 쿠키에 설정한다")
+        void success_withNickname_reissuesToken() throws Exception {
             Long userId = 1L;
+            LoginResult loginResult = new LoginResult("newAccessToken", "newRefreshToken", userId, "새닉네임", "USER", null);
 
             given(userService.updateInfo(eq(userId), any()))
                     .willReturn(new UserUpdateResponse(userId, "새닉네임"));
+            given(authService.reissueAfterNicknameChange(userId))
+                    .willReturn(loginResult);
 
             mockMvc.perform(patch("/api/v1/users/1")
                             .contentType(MediaType.APPLICATION_JSON)
-                            .content("{\"nickname\":\"새닉네임\",\"password\":\"newPass12\"}"))
+                            .content("{\"nickname\":\"새닉네임\"}"))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.data.userId").value(1))
                     .andExpect(jsonPath("$.data.nickname").value("새닉네임"))
                     .andExpect(jsonPath("$.message").value("내 정보 수정이 완료되었습니다."));
+
+            verify(authService).reissueAfterNicknameChange(userId);
+            verify(cookieUtil).addAllTokenCookies(any(), eq("newAccessToken"), eq("newRefreshToken"));
+        }
+
+        @Test
+        @DisplayName("성공 - 닉네임 없이 수정 시 토큰 재발급하지 않는다")
+        void success_withoutNickname_noReissue() throws Exception {
+            Long userId = 1L;
+
+            given(userService.updateInfo(eq(userId), any()))
+                    .willReturn(new UserUpdateResponse(userId, "기존닉네임"));
+
+            mockMvc.perform(patch("/api/v1/users/1")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"currentPassword\":\"oldPass12\",\"password\":\"newPass12\"}"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.message").value("내 정보 수정이 완료되었습니다."));
+
+            verify(authService, never()).reissueAfterNicknameChange(any());
+            verify(cookieUtil, never()).addAllTokenCookies(any(), any(), any());
         }
 
         @Test
@@ -114,7 +145,7 @@ class UserControllerTest {
 
             mockMvc.perform(patch("/api/v1/users/1")
                             .contentType(MediaType.APPLICATION_JSON)
-                            .content("{\"nickname\":\"새닉네임\",\"password\":\"newPass12\"}"))
+                            .content("{\"nickname\":\"새닉네임\"}"))
                     .andExpect(status().isNotFound())
                     .andExpect(jsonPath("$.message").value("해당 사용자를 찾을 수 없습니다."));
         }

--- a/front/src/app/(main)/users/[userId]/page.tsx
+++ b/front/src/app/(main)/users/[userId]/page.tsx
@@ -91,7 +91,7 @@ export default function MyPage() {
       setUpdateError("닉네임 또는 비밀번호를 입력하세요.");
       return;
     }
-    if (!isOAuthUser && newPassword.trim() && !currentPassword.trim()) {
+    if (!isOAuthUser && (newPassword.trim() || newNickname.trim()) && !currentPassword.trim()) {
       setUpdateError("현재 비밀번호를 입력하세요.");
       return;
     }
@@ -102,7 +102,7 @@ export default function MyPage() {
     setUpdating(true);
     try {
       const body: any = {};
-      if (!isOAuthUser && newPassword.trim()) body.currentPassword = currentPassword;
+      if (!isOAuthUser && (newPassword.trim() || newNickname.trim())) body.currentPassword = currentPassword;
       if (newNickname.trim()) body.nickname = newNickname;
       if (newPassword.trim()) body.password = newPassword;
       await api.patch(`/users/${myUserId}`, body);
@@ -280,7 +280,7 @@ export default function MyPage() {
             {!isOAuthUser && (
               <input
                 type="password"
-                placeholder="현재 비밀번호 (비밀번호 변경 시 필요)"
+                placeholder="현재 비밀번호 (닉네임/비밀번호 변경 시 필요)"
                 value={currentPassword}
                 onChange={(e) => setCurrentPassword(e.target.value)}
                 onKeyDown={handleCapsLock}


### PR DESCRIPTION
## 💡 PR 목적
<!-- 이 PR의 목적을 설명해주세요. (예: 어떤 기능을 추가/수정/삭제했나요?) -->
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타:

## 📝 변경 사항
AuthService.java
- reissueAfterNicknameChange(Long userId) 메서드 추가

AuthServiceImpl.java
- reissueAfterNicknameChange() 구현
- DB에서 최신 닉네임 조회 후 tokenVersion 증가 없이(세션 유지) 새 access/refresh token 발급 및 저장

UserController.java
- AuthService, CookieUtil 의존성 추가
- updateMyInfo(): 닉네임 변경 요청 시 토큰 재발급 후 쿠키 덮어쓰기

front/.../users/[userId]/page.tsx
- 닉네임 변경 시에도 currentPassword를 요구하고 body에 포함하도록 수정
- placeholder 텍스트 "비밀번호 변경 시 필요" → "닉네임/비밀번호 변경 시 필요"

AuthServiceImplTest.java
- reissueAfterNicknameChange 성공 / USER_NOT_FOUND / TOKEN_INVALID 케이스 3개 추가

UserControllerTest.java
- AuthService mock 추가
- 닉네임 변경 시 토큰 재발급 + 쿠키 설정 확인 테스트 추가
- 닉네임 없이 수정 시 재발급 미호출 확인 테스트 추가

## 🛠️ 테스트 방법
- 실제 테스트
- 단위 테스트 전체 통과

## 📌 관련 이슈
<!-- PR과 관련된 이슈 번호를 적어주세요. (예: #1, #2) -->
- Close #212 
