### PR TITLE
[#216][Test] 서버 서능 확인용 부하테스트

### DIFF
--- a/back/docker-compose.yml
+++ b/back/docker-compose.yml
@@ -34,7 +34,6 @@ services:
   grafana:
     image: grafana/grafana:latest
     container_name: dabjeongneo-grafana
-
     restart: always
     ports:
       - "3001:3000"

--- a/back/docker-compose.yml
+++ b/back/docker-compose.yml
@@ -34,6 +34,7 @@ services:
   grafana:
     image: grafana/grafana:latest
     container_name: dabjeongneo-grafana
+
     restart: always
     ports:
       - "3001:3000"

--- a/back/grafana/dashboards/k6-dashboard.json
+++ b/back/grafana/dashboards/k6-dashboard.json
@@ -334,7 +334,6 @@
               "mode": "off"
             }
           },
-          "decimals": 2,
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -348,8 +347,7 @@
                 "value": 80
               }
             ]
-          },
-          "unit": "reqps"
+          }
         },
         "overrides": []
       },
@@ -535,80 +533,33 @@
         "type": "influxdb",
         "uid": "${DS_INFLUXDB}"
       },
-      "description": "check 결과의 평균값을 기준으로 각 검증 항목 성공률을 원형 차트로 봅니다.",
+      "description": "API별 실패율을 출력합니다",
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "fillOpacity": 80,
+            "gradientMode": "none",
             "hideFrom": {
               "legend": false,
               "tooltip": false,
               "viz": false
+            },
+            "lineWidth": 0,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
             }
           },
-          "decimals": 2,
-          "mappings": [],
-          "max": 1,
-          "min": 0,
-          "unit": "percentunit"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 14
-      },
-      "id": 8,
-      "options": {
-        "displayLabels": [
-          "name",
-          "percent"
-        ],
-        "legend": {
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true
-        },
-        "pieType": "pie",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "sort": "desc",
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.4.2",
-      "targets": [
-        {
-          "query": "SELECT mean(\"value\") FROM \"checks\" WHERE $timeFilter GROUP BY \"check\"",
-          "rawQuery": true,
-          "refId": "A",
-          "resultFormat": "time_series"
-        }
-      ],
-      "title": "체크 성공률 분포",
-      "type": "piechart"
-    },
-    {
-      "datasource": {
-        "type": "influxdb",
-        "uid": "${DS_INFLUXDB}"
-      },
-      "description": "엔드포인트별 평균 응답 시간을 한눈에 비교합니다. 새 테스트가 추가돼도 자동으로 항목이 생깁니다.",
-      "fieldConfig": {
-        "defaults": {
-          "decimals": 2,
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -618,61 +569,55 @@
                 "value": 0
               },
               {
-                "color": "yellow",
-                "value": 300
-              },
-              {
                 "color": "red",
-                "value": 1000
+                "value": 80
               }
             ]
-          },
-          "unit": "ms"
+          }
         },
         "overrides": []
       },
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 12,
+        "x": 0,
         "y": 14
       },
-      "id": 7,
+      "id": 10,
       "options": {
-        "displayMode": "gradient",
+        "barRadius": 0,
+        "barWidth": 0.75,
+        "fullHighlight": false,
+        "groupWidth": 0.7,
         "legend": {
           "calcs": [],
           "displayMode": "list",
           "placement": "bottom",
-          "showLegend": false
+          "showLegend": true
         },
-        "maxVizHeight": 300,
-        "minVizHeight": 16,
-        "minVizWidth": 8,
-        "namePlacement": "auto",
-        "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
+        "orientation": "auto",
+        "showValue": "auto",
+        "stacking": "none",
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
         },
-        "showUnfilled": true,
-        "sizing": "auto",
-        "valueMode": "color"
+        "xField": "api",
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 0
       },
       "pluginVersion": "12.4.2",
       "targets": [
         {
-          "query": "SELECT mean(\"value\") FROM \"http_req_duration\" WHERE $timeFilter GROUP BY \"url\"",
+          "query": "SELECT mean(\"value\") FROM \"http_req_failed\" WHERE $timeFilter GROUP BY \"api\"",
           "rawQuery": true,
           "refId": "A",
-          "resultFormat": "time_series"
+          "resultFormat": "table"
         }
       ],
-      "title": "URL별 평균 응답 시간",
-      "type": "bargauge"
+      "title": "API별 실패율",
+      "type": "barchart"
     },
     {
       "datasource": {
@@ -773,8 +718,8 @@
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 0,
-        "y": 22
+        "x": 12,
+        "y": 14
       },
       "id": 9,
       "options": {
@@ -813,19 +758,10 @@
         "type": "influxdb",
         "uid": "${DS_INFLUXDB}"
       },
-      "description": "엔드포인트별 요청 수, 평균 응답 시간, p95 응답 시간을 표로 정리합니다.",
+      "description": "API별 평균 응답 시간을 한눈에 비교합니다. 새 테스트가 추가돼도 자동으로 항목이 생깁니다.",
       "fieldConfig": {
         "defaults": {
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "footer": {
-              "reducers": []
-            },
-            "inspect": false
-          },
+          "decimals": 2,
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -835,11 +771,85 @@
                 "value": 0
               },
               {
+                "color": "yellow",
+                "value": 300
+              },
+              {
                 "color": "red",
-                "value": 80
+                "value": 1000
               }
             ]
-          }
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 22
+      },
+      "id": 7,
+      "options": {
+        "displayMode": "gradient",
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "maxVizHeight": 300,
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "query": "SELECT mean(\"value\") FROM \"http_req_duration\" WHERE $timeFilter GROUP BY \"api\"",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "API별 평균 응답 시간",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_INFLUXDB}"
+      },
+      "description": "check 결과의 평균값을 기준으로 각 검증 항목 성공률을 원형 차트로 봅니다.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "decimals": 2,
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "unit": "percentunit"
         },
         "overrides": []
       },
@@ -849,22 +859,40 @@
         "x": 12,
         "y": 22
       },
-      "id": 10,
+      "id": 8,
       "options": {
-        "cellHeight": "sm",
-        "showHeader": true
+        "displayLabels": [],
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "pieType": "pie",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "sort": "desc",
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
       },
       "pluginVersion": "12.4.2",
       "targets": [
         {
-          "query": "SELECT count(\"value\") AS \"요청 수\", mean(\"value\") AS \"평균 응답 시간(ms)\", percentile(\"value\",95) AS \"p95 응답 시간(ms)\" FROM \"http_req_duration\" WHERE $timeFilter GROUP BY \"url\"",
+          "query": "SELECT mean(\"value\") FROM \"checks\" WHERE $timeFilter GROUP BY \"check\"",
           "rawQuery": true,
           "refId": "A",
-          "resultFormat": "table"
+          "resultFormat": "time_series"
         }
       ],
-      "title": "URL별 성능 요약표",
-      "type": "table"
+      "title": "체크 성공률 분포",
+      "type": "piechart"
     }
   ],
   "preload": false,

--- a/back/k6/README.md
+++ b/back/k6/README.md
@@ -76,6 +76,7 @@ docker compose --profile loadtest run --rm k6 run --out influxdb=http://influxdb
 | `setup-users.js` | 부하테스트용 유저 50명 사전 생성 (1회 실행) | ✅ |
 | `refresh-token-test.js` | 로그인 → reissue 3회 → 로그아웃 | ❌ |
 | `ranking-test.js` | 랭킹 조회 (all / weekly / monthly 분산) | ❌ |
+| `lobby-scenario-test.js` | 복합 시나리오 (browser 30VU + creator 20VU 동시) | ❌ (자체 정리) |
 
 ---
 
@@ -90,6 +91,9 @@ docker compose --profile loadtest run --rm k6 run --out influxdb=http://influxdb
 
 # 3. 랭킹 조회 부하테스트
 docker compose --profile loadtest run --rm k6 run --out influxdb=http://influxdb:8086/k6 ranking-test.js
+
+# 4. 복합 시나리오 부하테스트 (browser + creator 동시)
+docker compose --profile loadtest run --rm k6 run --out influxdb=http://influxdb:8086/k6 lobby-scenario-test.js
 ```
 
 ---
@@ -123,9 +127,11 @@ bash k6/cleanup.sh
 | 실패율 | HTTP 요청 실패 비율. 0에 가까울수록 안정적 |
 | VU | 동시 가상 사용자 수 |
 
-**threshold (통과 기준):**
-- 실패율 < 1%
-- p95 응답시간 < 500ms
+**threshold (통과 기준, 로컬 환경):**
+- 실패율 < 5%
+- p95 응답시간 < 3000ms
+
+> EC2 목표: 실패율 < 1%, p95 < 1000ms
 
 ---
 

--- a/back/k6/scripts/lobby-scenario-test.js
+++ b/back/k6/scripts/lobby-scenario-test.js
@@ -1,0 +1,279 @@
+/**
+ * lobby-scenario-test.js
+ *
+ * 실제 유저 행동 패턴을 재현하는 복합 시나리오 부하테스트입니다.
+ *
+ * [시나리오 1] browser (60 VU) - 로비 브라우저
+ *   로그인 → 방 목록 조회 3회 → 랭킹 조회 → 로그아웃
+ *
+ * [시나리오 2] creator (40 VU) - 콘텐츠 제작자
+ *   로그인 → 퀴즈셋 생성 → 퀴즈 3개 추가 → 방 생성 → 방 퇴장(방장) → 퀴즈셋 삭제(cascade 정리) → 로그아웃
+ *
+ * 측정 포인트:
+ *   - GET /api/v1/rooms          : findAll() 페이징 없는 전체 조회 성능
+ *   - POST /api/v1/quizsets      : DB 쓰기 + 트랜잭션 처리
+ *   - POST /api/v1/rooms         : quizSet 조회 + gameSession 저장
+ *   - DELETE /api/v1/rooms/{id}/leave : 방장 퇴장 → WebSocket broadcast + gameSession END
+ *   - GET /api/v1/rankings       : 캐시 히트율 확인
+ *
+ * 사전 준비: setup-users.js 로 테스트 유저 50명 생성 필요
+ */
+
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+const BASE_URL = 'http://host.docker.internal:8080';
+const TOTAL_USERS = 50;
+const JSON_HEADERS = { 'Content-Type': 'application/json' };
+
+export const options = {
+    scenarios: {
+        browser: {
+            executor: 'ramping-vus',
+            startVUs: 0,
+            stages: [
+                { duration: '30s', target: 30 },
+                { duration: '1m',  target: 30 },
+                { duration: '30s', target: 0  },
+            ],
+            env: { SCENARIO: 'browser' },
+            tags: { scenario: 'browser' },
+        },
+        creator: {
+            executor: 'ramping-vus',
+            startVUs: 0,
+            stages: [
+                { duration: '30s', target: 20 },
+                { duration: '1m',  target: 20 },
+                { duration: '30s', target: 0  },
+            ],
+            env: { SCENARIO: 'creator' },
+            tags: { scenario: 'creator' },
+        },
+    },
+    thresholds: {
+        // 전체 기준
+        // EC2 목표: rate<0.01 / p(95)<1000
+        'http_req_failed':                        ['rate<0.05'],
+        'http_req_duration':                      ['p(95)<3000'],
+        // 시나리오별 기준
+        // EC2 목표: browser p(95)<1000 / creator p(95)<2000
+        'http_req_duration{scenario:browser}':    ['p(95)<3000'],
+        'http_req_duration{scenario:creator}':    ['p(95)<3000'],
+        // API별 기준
+        // EC2 목표: room-list p(95)<1000 / ranking p(95)<500 / 쓰기 p(95)<2000
+        'http_req_duration{api:room-list}':       ['p(95)<3000'],
+        'http_req_duration{api:ranking}':         ['p(95)<2000'],
+        'http_req_duration{api:quizset-create}':  ['p(95)<3000'],
+        'http_req_duration{api:room-create}':     ['p(95)<3000'],
+    },
+};
+
+// ─────────────────────────────────────────────
+// 공통 헬퍼
+// ─────────────────────────────────────────────
+
+function getUser() {
+    const idx = (__VU - 1) % TOTAL_USERS;
+    return {
+        username: `loadtest${String(idx).padStart(4, '0')}`,
+        password: 'Test1234a',
+    };
+}
+
+function login() {
+    const user = getUser();
+    const jar = http.cookieJar();
+
+    const res = http.post(
+        `${BASE_URL}/api/v1/auth/login`,
+        JSON.stringify({ username: user.username, password: user.password }),
+        { jar, headers: JSON_HEADERS, tags: { api: 'login' } }
+    );
+
+    const ok = check(res, { '로그인 200': (r) => r.status === 200 });
+    if (!ok) {
+        console.error(`[VU ${__VU}] 로그인 실패: ${res.status} ${res.body}`);
+        return { jar, ok: false };
+    }
+
+    // 서버 쿠키가 Secure:true 로 설정되어 있어 HTTP 환경에서 자동 전송 안 됨
+    // → 토큰 값을 꺼내 Secure 없이 jar에 재등록
+    const accessToken  = res.cookies['accessToken']  && res.cookies['accessToken'][0].value;
+    const refreshToken = res.cookies['refreshToken'] && res.cookies['refreshToken'][0].value;
+
+    if (accessToken)  jar.set(BASE_URL, 'accessToken',  accessToken,  { secure: false });
+    if (refreshToken) jar.set(BASE_URL, 'refreshToken', refreshToken, { secure: false });
+
+    return { jar, ok: true };
+}
+
+function logout(jar) {
+    http.post(`${BASE_URL}/api/v1/auth/logout`, null, {
+        jar,
+        tags: { api: 'logout' },
+    });
+}
+
+// ─────────────────────────────────────────────
+// 시나리오 1: 로비 브라우저 (read-heavy)
+// ─────────────────────────────────────────────
+
+function browserScenario() {
+    const { jar, ok } = login();
+    if (!ok) return;
+
+    sleep(1);
+
+    // 방 목록 3회 조회 (findAll() 성능 측정 핵심)
+    for (let i = 0; i < 3; i++) {
+        const res = http.get(`${BASE_URL}/api/v1/rooms`, {
+            jar,
+            tags: { scenario: 'browser', api: 'room-list' },
+        });
+        check(res, { '방 목록 200': (r) => r.status === 200 });
+        sleep(1);
+    }
+
+    // 랭킹 조회 (캐시 히트율 측정)
+    const rankRes = http.get(`${BASE_URL}/api/v1/rankings?period=weekly`, {
+        jar,
+        tags: { scenario: 'browser', api: 'ranking' },
+    });
+    check(rankRes, { '랭킹 200': (r) => r.status === 200 });
+
+    sleep(1);
+    logout(jar);
+}
+
+// ─────────────────────────────────────────────
+// 시나리오 2: 콘텐츠 제작자 (write-heavy)
+// ─────────────────────────────────────────────
+
+function creatorScenario() {
+    const { jar, ok } = login();
+    if (!ok) return;
+
+    sleep(1);
+
+    // ── Step 1: 퀴즈셋 생성 ──────────────────────
+    const quizSetRes = http.post(
+        `${BASE_URL}/api/v1/quizsets`,
+        JSON.stringify({
+            title: `부하테스트 퀴즈셋 ${__VU}-${Date.now()}`,
+            description: '부하테스트용 퀴즈셋입니다.',
+        }),
+        { jar, headers: JSON_HEADERS, tags: { scenario: 'creator', api: 'quizset-create' } }
+    );
+
+    const quizSetOk = check(quizSetRes, { '퀴즈셋 생성 201': (r) => r.status === 201 });
+    if (!quizSetOk) {
+        logout(jar);
+        return;
+    }
+
+    // Location 헤더에서 quizSetId 추출: /api/v1/quizsets/{id}
+    const quizSetId = quizSetRes.headers['Location'].split('/').pop();
+
+    // ── Step 2: 퀴즈 3개 추가 (방 생성 시 maxQuizzes 충족을 위해 먼저 추가) ──
+    const quizzes = [
+        {
+            questionType: 'TEXT',
+            answerType: 'MULTIPLE_CHOICE',
+            content: '다음 중 Java의 특징이 아닌 것은?',
+            answer: '1',
+            choice1: '포인터 직접 조작',
+            choice2: '플랫폼 독립성',
+            choice3: '객체지향',
+            choice4: '자동 메모리 관리',
+        },
+        {
+            questionType: 'TEXT',
+            answerType: 'MULTIPLE_CHOICE',
+            content: 'HTTP 상태코드 404의 의미는?',
+            answer: '2',
+            choice1: '서버 내부 오류',
+            choice2: '리소스를 찾을 수 없음',
+            choice3: '권한 없음',
+            choice4: '요청 성공',
+        },
+        {
+            questionType: 'TEXT',
+            answerType: 'MULTIPLE_CHOICE',
+            content: 'Spring Boot의 기본 내장 서버는?',
+            answer: '3',
+            choice1: 'Jetty',
+            choice2: 'Undertow',
+            choice3: 'Tomcat',
+            choice4: 'Netty',
+        },
+    ];
+
+    for (const quiz of quizzes) {
+        const quizRes = http.post(
+            `${BASE_URL}/api/v1/quizsets/${quizSetId}/quizzes`,
+            JSON.stringify(quiz),
+            { jar, headers: JSON_HEADERS, tags: { scenario: 'creator', api: 'quiz-create' } }
+        );
+        check(quizRes, { '퀴즈 생성 201': (r) => r.status === 201 });
+        sleep(0.3);
+    }
+
+    // ── Step 3: 방 생성 ───────────────────────────
+    const roomRes = http.post(
+        `${BASE_URL}/api/v1/rooms`,
+        JSON.stringify({
+            roomName: `테스트방-VU${__VU}`,
+            quizSetId: parseInt(quizSetId),
+            maxQuizzes: 3,
+            maxPlayers: 4,
+        }),
+        { jar, headers: JSON_HEADERS, tags: { scenario: 'creator', api: 'room-create' } }
+    );
+
+    const roomOk = check(roomRes, { '방 생성 201': (r) => r.status === 201 });
+    if (!roomOk) {
+        // 방 생성 실패 시 퀴즈셋 삭제 후 종료 (cascade로 퀴즈도 삭제됨)
+        http.del(`${BASE_URL}/api/v1/quizsets/${quizSetId}`, null, { jar });
+        logout(jar);
+        return;
+    }
+
+    // Location 헤더에서 roomId 추출: /api/v1/rooms/{id}
+    const roomId = roomRes.headers['Location'].split('/').pop();
+
+    sleep(1);
+
+    // ── Step 4: 방 퇴장 (방장 퇴장 → room status END + WebSocket broadcast) ──
+    const leaveRes = http.del(
+        `${BASE_URL}/api/v1/rooms/${roomId}/leave`,
+        null,
+        { jar, tags: { scenario: 'creator', api: 'room-leave' } }
+    );
+    check(leaveRes, { '방 퇴장 204': (r) => r.status === 204 });
+
+    sleep(0.5);
+
+    // ── Step 5: 퀴즈셋 삭제 (북마크·게임기록·게임세션·퀴즈 cascade 삭제) ──
+    const deleteRes = http.del(
+        `${BASE_URL}/api/v1/quizsets/${quizSetId}`,
+        null,
+        { jar, tags: { scenario: 'creator', api: 'quizset-delete' } }
+    );
+    check(deleteRes, { '퀴즈셋 삭제 204': (r) => r.status === 204 });
+
+    sleep(1);
+    logout(jar);
+}
+
+// ─────────────────────────────────────────────
+// 진입점
+// ─────────────────────────────────────────────
+
+export default function () {
+    if (__ENV.SCENARIO === 'browser') {
+        browserScenario();
+    } else {
+        creatorScenario();
+    }
+}

--- a/back/k6/scripts/refresh-token-test.js
+++ b/back/k6/scripts/refresh-token-test.js
@@ -41,6 +41,12 @@ export default function () {
         return;
     }
 
+    // Secure:true 쿠키는 HTTP에서 자동 전송 안 됨 → 수동으로 jar에 재등록
+    const accessToken  = loginRes.cookies['accessToken']  && loginRes.cookies['accessToken'][0].value;
+    const refreshToken = loginRes.cookies['refreshToken'] && loginRes.cookies['refreshToken'][0].value;
+    if (accessToken)  jar.set(BASE_URL, 'accessToken',  accessToken,  { secure: false });
+    if (refreshToken) jar.set(BASE_URL, 'refreshToken', refreshToken, { secure: false });
+
     sleep(1);
 
     // 2. reissue 3회 반복

--- a/back/src/main/resources/application-dev.yml
+++ b/back/src/main/resources/application-dev.yml
@@ -4,9 +4,6 @@ spring:
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     driver-class-name: org.postgresql.Driver
-    hikari:
-      maximum-pool-size: 10
-
   jpa:
     properties:
       hibernate:

--- a/back/src/main/resources/application-dev.yml
+++ b/back/src/main/resources/application-dev.yml
@@ -4,6 +4,8 @@ spring:
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     driver-class-name: org.postgresql.Driver
+    hikari:
+      maximum-pool-size: 10
 
   jpa:
     properties:


### PR DESCRIPTION
## 💡 PR 목적
<!-- 이 PR의 목적을 설명해주세요. (예: 어떤 기능을 추가/수정/삭제했나요?) -->
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [x] 문서 수정
- [ ] 기타:

## 📝 변경 사항
  새 파일                                                                                                      
  - k6/scripts/lobby-scenario-test.js — 복합 시나리오 부하테스트 (browser 30VU + creator 20VU)
                                                                                                               
  수정 파일       
  - k6/README.md — lobby-scenario-test.js 추가, threshold 기준 문서화 (로컬/EC2 목표 분리)
  - k6/scripts/refresh-token-test.js — Secure 쿠키 우회 처리 추가
  - grafana/dashboards/k6-dashboard.json — 대시보드 개선 (API별 지표 패널 추가)

## 🛠️ 테스트 방법
<img width="1006" height="715" alt="스크린샷 2026-04-10 112713" src="https://github.com/user-attachments/assets/9c0b9712-ede7-42de-9354-5fd286ddcb33" />


## 📌 관련 이슈
<!-- PR과 관련된 이슈 번호를 적어주세요. (예: #1, #2) -->
- Close #216 
